### PR TITLE
Use openzeppelin's Ownable.sol for whitelist 

### DIFF
--- a/contracts/Whitelist.sol
+++ b/contracts/Whitelist.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: BSL 1.1
 pragma solidity ^0.8.15;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
 // Contract that allows an admin to add/remove addresses from the whitelist,
 // and allows whitelisted addresses to mint/burn native tokens.
-contract Whitelist {
-    address public admin;
+contract Whitelist is Ownable {
+
     mapping(address => bool) public whitelistedAddresses;
 
     // Mint/burn precompile addresses.
@@ -12,21 +14,15 @@ contract Whitelist {
     address constant MINT = address(0x89);
     address constant BURN = address(0x90);
 
-    constructor(address _admin) {
-        require(_admin != address(0), "Admin address cannot be zero");
-        admin = _admin;
+    constructor(address _owner) Ownable() {
+        _transferOwnership(_owner);
     }
 
-    modifier onlyAdmin() {
-        require(msg.sender == admin, "Only admin can call this function");
-        _;
-    }
-
-    function addToWhitelist(address _address) external onlyAdmin {
+    function addToWhitelist(address _address) external onlyOwner {
         whitelistedAddresses[_address] = true;
     }
 
-    function removeFromWhitelist(address _address) external onlyAdmin {
+    function removeFromWhitelist(address _address) external onlyOwner {
         whitelistedAddresses[_address] = false;
     }
 

--- a/test/WhitelistTest.sol
+++ b/test/WhitelistTest.sol
@@ -44,7 +44,7 @@ contract WhitelistTest is Test {
 
     function test_RevertNormalUserAddToWhitelist() public {
         vm.prank(normalUser);
-        vm.expectRevert("Only admin can call this function");
+        vm.expectRevert("Ownable: caller is not the owner");
         whitelist.addToWhitelist(addressInstance);
     }
 
@@ -53,7 +53,7 @@ contract WhitelistTest is Test {
         whitelist.addToWhitelist(addressInstance);
         assertTrue(whitelist.isWhitelisted(addressInstance));
         vm.prank(normalUser);
-        vm.expectRevert("Only admin can call this function");
+        vm.expectRevert("Ownable: caller is not the owner");
         whitelist.removeFromWhitelist(addressInstance);
     }
 }


### PR DESCRIPTION
Extends https://github.com/primevprotocol/contracts/pull/58 by following patterns of other contracts in this repo and using openzeppellin's Ownable.sol contract 