### PR TITLE
feat: check req burn balance at contract level

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ UserRegistry deployed to: 0xe38B5a8C41f307646F395030992Aa008978E2699
 ProviderRegistry deployed to: 0x7fA45D14358B698Bd85a0a2B03720A6Fe4b566d7
 PreConfCommitmentStore deployed to: 0x8B0F623dCD54cA50CD154B3dDCbB8436E876b019
 Oracle deployed to: 0x628F330Ae673df7D73d943f9590A4d643e4197f6
-Whitelist deployed to: 0x07e77fdc3DF92E58c9230eEFaABdBd92a8D0c2Af
+Whitelist deployed to: 0x5D1415C0973034d162F5FEcF19B50dA057057e29
 ```
 
 #### Test Contracts

--- a/contracts/Whitelist.sol
+++ b/contracts/Whitelist.sol
@@ -42,9 +42,13 @@ contract Whitelist is Ownable {
     }
 
     // Burns native tokens if the sender is whitelisted.
-    // See: https://github.com/primevprotocol/go-ethereum/blob/precompile-updates/core/vm/contracts_with_ctx.go#L111
     function burn(address _burnFrom, uint256 _amount) external {
         require(isWhitelisted(msg.sender), "Sender is not whitelisted");
+        
+        // require _burnFrom has enough balance. This check is NOT done at the precompile level.
+        // Reason: https://github.com/primevprotocol/go-ethereum/blob/8735a9bbe6965ed68371472cb0794d8659a94428/core/vm/contracts_with_ctx.go#L115
+        require(_burnFrom.balance >= _amount, "Insufficient balance");
+
         bool success;
         (success, ) = BURN.call{value: 0, gas: gasleft()}(
             abi.encode(_burnFrom, _amount) 

--- a/scripts/DeployScripts.s.sol
+++ b/scripts/DeployScripts.s.sol
@@ -18,7 +18,7 @@ contract Create2Deployer {
 
     function checkDeployer() internal view {
         if (msg.sender != expectedDeployer) {
-            console.log("Warning: deployer is not expected address of 0xBe3dEF3973584FdcC1326634aF188f0d9772D57D. Contracts addresses will not match documentation");
+            console.log("Warning: deployer is not expected address of 0xBcA333b67fb805aB18B4Eb7aa5a0B09aB25E5ce2. Contracts addresses will not match documentation");
         }
     }
 

--- a/scripts/DeployScripts.s.sol
+++ b/scripts/DeployScripts.s.sol
@@ -18,7 +18,7 @@ contract Create2Deployer {
 
     function checkDeployer() internal view {
         if (msg.sender != expectedDeployer) {
-            console.log("Warning: deployer is not expected address of 0xBcA333b67fb805aB18B4Eb7aa5a0B09aB25E5ce2. Contracts addresses will not match documentation");
+            console.log("Warning: deployer is not expected address of 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266. Contracts addresses will not match documentation");
         }
     }
 


### PR DESCRIPTION
See https://github.com/primevprotocol/go-ethereum/blob/8735a9bbe6965ed68371472cb0794d8659a94428/core/vm/contracts_with_ctx.go#L115 for context. 

Changes in bytecode will cause whitelist to be deployed at new contract addr 