### PR TITLE
Adds a read function on the Treasury Contract

### DIFF
--- a/contracts/BidderRegistry.sol
+++ b/contracts/BidderRegistry.sol
@@ -113,6 +113,13 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
     }
     
     /**
+     * @dev Get the amount assigned to the fee recipient (treasury).
+     */
+    function getFeeRecipientAmount() external onlyOwner view returns (uint256) {
+        return feeRecipientAmount;
+    }
+
+    /**
      * @dev Internal function for bidder registration and staking.
      */
     function prepay() public payable {

--- a/contracts/BidderRegistry.sol
+++ b/contracts/BidderRegistry.sol
@@ -41,7 +41,7 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
     mapping(address => uint256) public providerAmount;
 
     /// @dev Event emitted when a bidder is registered with their prepayed amount
-    event BidderRegistered(address indexed bidder, uint256 prepayedAmount);
+    event BidderRegistered(address indexed bidder, uint256 prepaidAmount);
 
     /// @dev Event emitted when funds are retrieved from a bidder's prepay
     event FundsRetrieved(address indexed bidder, uint256 amount);
@@ -210,13 +210,13 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
         require(success, "Couldn't transfer to provider");
     }
 
-    function withdrawPrepayedAmount(address payable bidder) external nonReentrant {
-        uint256 prepayedAmount = bidderPrepaidBalances[bidder];
+    function withdrawPrepaidAmount(address payable bidder) external nonReentrant {
+        uint256 prepaidAmount = bidderPrepaidBalances[bidder];
         bidderPrepaidBalances[bidder] = 0;
         require(msg.sender == bidder, "Only bidder can unprepay");
-        require(prepayedAmount > 0, "Provider Prepayd Amount is zero");
+        require(prepaidAmount > 0, "Provider Prepayd Amount is zero");
 
-        (bool success, ) = bidder.call{value: prepayedAmount}("");
+        (bool success, ) = bidder.call{value: prepaidAmount}("");
         require(success, "Couldn't transfer prepay to bidder");
     }
 

--- a/test/BidderRegistryTest.sol
+++ b/test/BidderRegistryTest.sol
@@ -140,6 +140,7 @@ contract BidderRegistryTest is Test {
 
         assertEq(providerAmount, 900000000000000000);
         assertEq(feeRecipientAmount, 100000000000000000);
+        assertEq(bidderRegistry.getFeeRecipientAmount(), 100000000000000000);
         assertEq(bidderRegistry.bidderPrepaidBalances(bidder), 1 ether);
     }
 
@@ -198,6 +199,7 @@ contract BidderRegistryTest is Test {
         uint256 balanceAfter = feeRecipient.balance;
         assertEq(balanceAfter - balanceBefore, 100000000000000000);
         assertEq(bidderRegistry.feeRecipientAmount(), 0);
+        assertEq(bidderRegistry.getFeeRecipientAmount(), 0);
     }
 
     function testFail_withdrawFeeRecipientAmount() public {

--- a/test/BidderRegistryTest.sol
+++ b/test/BidderRegistryTest.sol
@@ -234,7 +234,7 @@ contract BidderRegistryTest is Test {
         bidderRegistry.prepay{value: 5 ether}();
         uint256 balanceBefore = address(bidder).balance;
         vm.prank(bidder);
-        bidderRegistry.withdrawPrepayedAmount(payable(bidder));
+        bidderRegistry.withdrawPrepaidAmount(payable(bidder));
         uint256 balanceAfter = address(bidder).balance;
         assertEq(balanceAfter - balanceBefore, 5 ether);
         assertEq(bidderRegistry.bidderPrepaidBalances(bidder), 0);
@@ -244,13 +244,13 @@ contract BidderRegistryTest is Test {
         bidderRegistry.setPreconfirmationsContract(address(this));
         vm.prank(bidder);
         bidderRegistry.prepay{value: 5 ether}();
-        bidderRegistry.withdrawPrepayedAmount(payable(bidder));
+        bidderRegistry.withdrawPrepaidAmount(payable(bidder));
     }
 
     function testFail_withdrawStakedAmountStakeZero() public {
         bidderRegistry.setPreconfirmationsContract(address(this));
         vm.prank(bidder);
-        bidderRegistry.withdrawPrepayedAmount(payable(bidder));
+        bidderRegistry.withdrawPrepaidAmount(payable(bidder));
     }
 
     function test_withdrawProtocolFee() public {


### PR DESCRIPTION
* sets retrieval to `onlyowner`, though anyone can read the storage slot

### New Contract Deployment
```
  BidderRegistry deployed to: 0x5340b92E261141D6B4D0DC6F847667E5e4A63544
  ProviderRegistry deployed to: 0xeA73E67c2E34C4E02A2f3c5D416F59B76e7617fC
  PreConfCommitmentStore deployed to: 0x451656c1E7eDf82397EBE04f38819c9970AA3658
  ProviderRegistry updated with PreConfCommitmentStore address: 0x451656c1E7eDf82397EBE04f38819c9970AA3658
  BidderRegistry updated with PreConfCommitmentStore address: 0x451656c1E7eDf82397EBE04f38819c9970AA3658
  Oracle deployed to: 0x943685b6999626D2323526ce3fb6EF1786Ee8Ee3
  PreConfCommitmentStore updated with Oracle address: 0x943685b6999626D2323526ce3fb6EF1786Ee8Ee3
  ```