### PR TITLE
Adds Idempotent Funds movement with Bid storage during pre-confirmation.

### DIFF
--- a/contracts/BidderRegistry.sol
+++ b/contracts/BidderRegistry.sol
@@ -143,7 +143,7 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
         return bidderPrepaidBalances[bidder];
     }
 
-    function IdempotentBidFundsMovement(bytes32 commitmentDigest, uint64 bid, address bidder) external onlyPreConfirmationEngine(){
+    function LockBidFunds(bytes32 commitmentDigest, uint64 bid, address bidder) external onlyPreConfirmationEngine(){
         BidState memory bidState = BidPayment[commitmentDigest];
         if (bidState.state == State.UnPreConfirmed) {
             BidPayment[commitmentDigest] = BidState({
@@ -192,7 +192,7 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
      * @dev reenterancy not necessary but still putting here for precaution
      * @param bidID is the Bid ID that allows us to identify the bid, and prepayment
      */
-    function returnFunds(bytes32 bidID) external nonReentrant onlyPreConfirmationEngine() {
+    function unlockFunds(bytes32 bidID) external nonReentrant onlyPreConfirmationEngine() {
         BidState memory bidState = BidPayment[bidID];
         require(bidState.state == State.PreConfirmed, "The bid was not preconfirmed");
         uint256 amt = bidState.bidAmt;

--- a/contracts/BidderRegistry.sol
+++ b/contracts/BidderRegistry.sol
@@ -145,7 +145,7 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
 
     function LockBidFunds(bytes32 commitmentDigest, uint64 bid, address bidder) external onlyPreConfirmationEngine(){
         BidState memory bidState = BidPayment[commitmentDigest];
-        if (bidState.state == State.UnPreConfirmed) {
+        if (bidState.state == State.Undefined) {
             BidPayment[commitmentDigest] = BidState({
                 bidAmt: bid,
                 state: State.PreConfirmed,

--- a/contracts/BidderRegistry.sol
+++ b/contracts/BidderRegistry.sol
@@ -246,7 +246,7 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
         uint256 prepaidAmount = bidderPrepaidBalances[bidder];
         bidderPrepaidBalances[bidder] = 0;
         require(msg.sender == bidder, "only bidder can unprepay");
-        require(prepaidAmount > 0, "provider Prepayd Amount is zero");
+        require(prepaidAmount > 0, "bidder prepaid Amount is zero");
 
         (bool success, ) = bidder.call{value: prepaidAmount}("");
         require(success, "couldn't transfer prepay to bidder");

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -120,6 +120,12 @@ contract Oracle is Ownable {
     }
 
     /**
+     */
+    function returnFunds(bytes32 bidID) external onlyOwner {
+        // Bidder registery.returnFunds(bidID);
+    }
+
+    /**
      * @dev Internal function to process a commitment, either slashing or rewarding based on the commitment's state.
      * @param commitmentIndex The id of the commitment to be processed.
      * @param isSlash Determines if the commitment should be slashed or rewarded.

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -126,6 +126,8 @@ contract Oracle is Ownable {
     }
 
     /**
+        * @dev unlocks funds to the bidders assosciated with BidIDs in the input array.
+        * @param bidIDs The array of BidIDs to unlock funds for.
      */
     function unlockFunds(bytes32[] memory bidIDs) external onlyOwner {
         for (uint256 i = 0; i < bidIDs.length; i++) {

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -127,8 +127,10 @@ contract Oracle is Ownable {
 
     /**
      */
-    function returnFunds(bytes32 bidID) external onlyOwner {
-        bidderRegistry.returnFunds(bidID);
+    function returnFunds(bytes32[] memory bidIDs) external onlyOwner {
+        for (uint256 i = 0; i < bidIDs.length; i++) {
+            bidderRegistry.returnFunds(bidIDs[i]);
+        }
     }
 
     /**

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -127,9 +127,9 @@ contract Oracle is Ownable {
 
     /**
      */
-    function returnFunds(bytes32[] memory bidIDs) external onlyOwner {
+    function unlockFunds(bytes32[] memory bidIDs) external onlyOwner {
         for (uint256 i = 0; i < bidIDs.length; i++) {
-            bidderRegistry.returnFunds(bidIDs[i]);
+            bidderRegistry.unlockFunds(bidIDs[i]);
         }
     }
 

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -5,6 +5,8 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {PreConfCommitmentStore} from "./PreConfirmations.sol";
 import {IProviderRegistry} from "./interfaces/IProviderRegistry.sol";
 import {IPreConfCommitmentStore} from './interfaces/IPreConfirmations.sol';
+import {IBidderRegistry} from './interfaces/IBidderRegistry.sol';
+
 
 /// @title Oracle Contract
 /// @author Kartik Chopra
@@ -44,6 +46,8 @@ contract Oracle is Ownable {
     /// @dev Reference to the PreConfCommitmentStore contract interface.
     IPreConfCommitmentStore private preConfContract;
 
+    IBidderRegistry private bidderRegistry;
+
     /**
      * @dev Constructor to initialize the contract with a PreConfirmations contract.
      * @param _preConfContract The address of the pre-confirmations contract.
@@ -52,10 +56,12 @@ contract Oracle is Ownable {
      */
     constructor(
         address _preConfContract,
+        address _bidderRegistry,
         uint256 _nextRequestedBlockNumber,
         address _owner
     ) Ownable() {
         preConfContract = IPreConfCommitmentStore(_preConfContract);
+        bidderRegistry = IBidderRegistry(_bidderRegistry);
         nextRequestedBlockNumber = _nextRequestedBlockNumber;
         _transferOwnership(_owner);
     }
@@ -122,7 +128,7 @@ contract Oracle is Ownable {
     /**
      */
     function returnFunds(bytes32 bidID) external onlyOwner {
-        // Bidder registery.returnFunds(bidID);
+        bidderRegistry.returnFunds(bidID);
     }
 
     /**

--- a/contracts/PreConfirmations.sol
+++ b/contracts/PreConfirmations.sol
@@ -408,11 +408,7 @@ contract PreConfCommitmentStore is Ownable {
             payable(commitment.bidder)
         );
 
-        // Return funds to bidder
-        bidderRegistry.retrieveFunds(
-            commitment.commitmentHash,
-            payable(commitment.bidder)
-        );
+        bidderRegistry.returnFunds(commitment.commitmentHash);
     }
 
     /**

--- a/contracts/PreConfirmations.sol
+++ b/contracts/PreConfirmations.sol
@@ -407,6 +407,12 @@ contract PreConfCommitmentStore is Ownable {
             commitment.commiter,
             payable(commitment.bidder)
         );
+
+        // Return funds to bidder
+        bidderRegistry.retrieveFunds(
+            commitment.commitmentHash,
+            payable(commitment.bidder)
+        );
     }
 
     /**
@@ -425,8 +431,7 @@ contract PreConfCommitmentStore is Ownable {
         commitmentsCount[commitment.commiter] -= 1;
 
         bidderRegistry.retrieveFunds(
-            commitment.bidder,
-            commitment.bid,
+            commitment.commitmentHash,
             payable(commitment.commiter)
         );
     }

--- a/contracts/PreConfirmations.sol
+++ b/contracts/PreConfirmations.sol
@@ -332,7 +332,7 @@ contract PreConfCommitmentStore is Ownable {
             commitmentsCount[commiterAddress] += 1;
 
             // Check if Bid has bid-amt stored
-            bidderRegistry.IdempotentBidFundsMovement(commitmentDigest, bid, bidderAddress);
+            bidderRegistry.LockBidFunds(commitmentDigest, bid, bidderAddress);
 
         }
 
@@ -408,7 +408,7 @@ contract PreConfCommitmentStore is Ownable {
             payable(commitment.bidder)
         );
 
-        bidderRegistry.returnFunds(commitment.commitmentHash);
+        bidderRegistry.unlockFunds(commitment.commitmentHash);
     }
 
     /**

--- a/contracts/PreConfirmations.sol
+++ b/contracts/PreConfirmations.sol
@@ -294,7 +294,7 @@ contract PreConfCommitmentStore is Ownable {
         );
         // This helps in avoiding stack too deep
         {
-            bytes32 preConfHash = getPreConfHash(
+            bytes32 commitmentDigest = getPreConfHash(
                 txnHash,
                 bid,
                 blockNumber,
@@ -302,7 +302,7 @@ contract PreConfCommitmentStore is Ownable {
                 _bytesToHexString(bidSignature)
             );
 
-            address commiterAddress = preConfHash.recover(commitmentSignature);
+            address commiterAddress = commitmentDigest.recover(commitmentSignature);
 
             require(stake > (10 * bid), "Stake too low");
 
@@ -314,13 +314,12 @@ contract PreConfCommitmentStore is Ownable {
                 blockNumber,
                 bHash,
                 txnHash,
-                preConfHash,
+                commitmentDigest,
                 bidSignature,
                 commitmentSignature
             );
 
             commitmentIndex = getCommitmentIndex(newCommitment);
-
 
             // Store commitment
             commitments[commitmentIndex] = newCommitment;
@@ -331,6 +330,10 @@ contract PreConfCommitmentStore is Ownable {
             
             commitmentCount++;
             commitmentsCount[commiterAddress] += 1;
+
+            // Check if Bid has bid-amt stored
+            bidderRegistry.IdempotentBidFundsMovement(commitmentDigest, bid, bidderAddress);
+
         }
 
         return commitmentIndex;

--- a/contracts/interfaces/IBidderRegistry.sol
+++ b/contracts/interfaces/IBidderRegistry.sol
@@ -27,12 +27,11 @@ interface IBidderRegistry {
     function prepay() external payable;
 
     function IdempotentBidFundsMovement(bytes32 commitmentDigest, uint64 bid, address bidder) external;
-    
+
     function getAllowance(address bidder) external view returns (uint256);
 
     function retrieveFunds(
-        address bidder,
-        uint256 amt,
+        bytes32 commitmentDigest,
         address payable provider
     ) external;
 }

--- a/contracts/interfaces/IBidderRegistry.sol
+++ b/contracts/interfaces/IBidderRegistry.sol
@@ -27,7 +27,7 @@ interface IBidderRegistry {
 
     function prepay() external payable;
 
-    function IdempotentBidFundsMovement(bytes32 commitmentDigest, uint64 bid, address bidder) external;
+    function LockBidFunds(bytes32 commitmentDigest, uint64 bid, address bidder) external;
 
     function getAllowance(address bidder) external view returns (uint256);
 
@@ -36,5 +36,5 @@ interface IBidderRegistry {
         address payable provider
     ) external;
 
-    function returnFunds(bytes32 bidID) external;
+    function unlockFunds(bytes32 bidID) external;
 }

--- a/contracts/interfaces/IBidderRegistry.sol
+++ b/contracts/interfaces/IBidderRegistry.sol
@@ -14,6 +14,7 @@ interface IBidderRegistry {
 
 
     struct BidState {
+        address bidder;
         uint64 bidAmt;
         State state;
     }
@@ -34,4 +35,6 @@ interface IBidderRegistry {
         bytes32 commitmentDigest,
         address payable provider
     ) external;
+
+    function returnFunds(bytes32 bidID) external;
 }

--- a/contracts/interfaces/IBidderRegistry.sol
+++ b/contracts/interfaces/IBidderRegistry.sol
@@ -20,7 +20,7 @@ interface IBidderRegistry {
     }
 
     enum State {
-        UnPreConfirmed,
+        Undefined,
         PreConfirmed,
         Withdrawn
     }

--- a/contracts/interfaces/IBidderRegistry.sol
+++ b/contracts/interfaces/IBidderRegistry.sol
@@ -12,8 +12,22 @@ interface IBidderRegistry {
         string commitmentSignature;
     }
 
+
+    struct BidState {
+        uint64 bidAmt;
+        State state;
+    }
+
+    enum State {
+        UnPreConfirmed,
+        PreConfirmed,
+        Withdrawn
+    }
+
     function prepay() external payable;
 
+    function IdempotentBidFundsMovement(bytes32 commitmentDigest, uint64 bid, address bidder) external;
+    
     function getAllowance(address bidder) external view returns (uint256);
 
     function retrieveFunds(

--- a/scripts/DeployScripts.s.sol
+++ b/scripts/DeployScripts.s.sol
@@ -63,7 +63,7 @@ contract DeployScript is Script, Create2Deployer {
         bidderRegistry.setPreconfirmationsContract(address(preConfCommitmentStore));
         console.log("BidderRegistry updated with PreConfCommitmentStore address:", address(preConfCommitmentStore));
 
-        Oracle oracle = new Oracle{salt: salt}(address(preConfCommitmentStore), nextRequestedBlockNumber, msg.sender);
+        Oracle oracle = new Oracle{salt: salt}(address(preConfCommitmentStore), address(bidderRegistry), nextRequestedBlockNumber, msg.sender);
         console.log("Oracle deployed to:", address(oracle));
 
         preConfCommitmentStore.updateOracle(address(oracle));

--- a/test/BidderRegistryTest.sol
+++ b/test/BidderRegistryTest.sol
@@ -129,12 +129,13 @@ contract BidderRegistryTest is Test {
     }
 
     function test_shouldRetrieveFunds() public {
+        bytes32 bidID = keccak256("1234");
         bidderRegistry.setPreconfirmationsContract(address(this));
         vm.prank(bidder);
         bidderRegistry.prepay{value: 2 ether}();
         address provider = vm.addr(4);
-
-        bidderRegistry.retrieveFunds(bidder, 1 ether, payable(provider));
+        bidderRegistry.IdempotentBidFundsMovement(bidID, 1 ether, bidder);
+        bidderRegistry.retrieveFunds(bidID, payable(provider));
         uint256 providerAmount = bidderRegistry.providerAmount(provider);
         uint256 feeRecipientAmount = bidderRegistry.feeRecipientAmount();
 
@@ -154,8 +155,9 @@ contract BidderRegistryTest is Test {
         vm.prank(bidder);
         bidderRegistry.prepay{value: 2 ether}();
         address provider = vm.addr(4);
-
-        bidderRegistry.retrieveFunds(bidder, 1 ether, payable(provider));
+        bytes32 bidID = keccak256("1234");
+        bidderRegistry.IdempotentBidFundsMovement(bidID, 1 ether, bidder);
+        bidderRegistry.retrieveFunds(bidID, payable(provider));
 
         uint256 feerecipientValueAfter = bidderRegistry.feeRecipientAmount();
         uint256 providerAmount = bidderRegistry.providerAmount(provider);
@@ -171,7 +173,9 @@ contract BidderRegistryTest is Test {
         bidderRegistry.prepay{value: 2 ether}();
         address provider = vm.addr(4);
         vm.expectRevert(bytes(""));
-        bidderRegistry.retrieveFunds(bidder, 1 ether, payable(provider));
+        bytes32 bidID = keccak256("1234");
+        bidderRegistry.IdempotentBidFundsMovement(bidID, 1 ether, bidder);
+        bidderRegistry.retrieveFunds(bidID, payable(provider));
     }
 
     function testFail_shouldRetrieveFundsGreaterThanStake() public {
@@ -184,8 +188,9 @@ contract BidderRegistryTest is Test {
         address provider = vm.addr(4);
         vm.expectRevert(bytes(""));
         vm.prank(address(this));
-
-        bidderRegistry.retrieveFunds(bidder, 3 ether, payable(provider));
+        bytes32 bidID = keccak256("1234");
+        bidderRegistry.IdempotentBidFundsMovement(bidID, 3 ether, bidder);
+        bidderRegistry.retrieveFunds(bidID, payable(provider));
     }
 
     function test_withdrawFeeRecipientAmount() public {
@@ -194,7 +199,9 @@ contract BidderRegistryTest is Test {
         bidderRegistry.prepay{value: 2 ether}();
         address provider = vm.addr(4);
         uint256 balanceBefore = feeRecipient.balance;
-        bidderRegistry.retrieveFunds(bidder, 1 ether, payable(provider));
+        bytes32 bidID = keccak256("1234");
+        bidderRegistry.IdempotentBidFundsMovement(bidID, 1 ether, bidder);
+        bidderRegistry.retrieveFunds(bidID, payable(provider));
         bidderRegistry.withdrawFeeRecipientAmount();
         uint256 balanceAfter = feeRecipient.balance;
         assertEq(balanceAfter - balanceBefore, 100000000000000000);
@@ -213,7 +220,9 @@ contract BidderRegistryTest is Test {
         bidderRegistry.prepay{value: 5 ether}();
         address provider = vm.addr(4);
         uint256 balanceBefore = address(provider).balance;
-        bidderRegistry.retrieveFunds(bidder, 2 ether, payable(provider));
+        bytes32 bidID = keccak256("1234");
+        bidderRegistry.IdempotentBidFundsMovement(bidID, 2 ether, bidder);
+        bidderRegistry.retrieveFunds(bidID, payable(provider));
         bidderRegistry.withdrawProviderAmount(payable(provider));
         uint256 balanceAfter = address(provider).balance;
         assertEq(balanceAfter - balanceBefore, 1800000000000000000);
@@ -260,7 +269,9 @@ contract BidderRegistryTest is Test {
         vm.prank(bidder);
         bidderRegistry.prepay{value: 5 ether}();
         uint256 balanceBefore = address(bidder).balance;
-        bidderRegistry.retrieveFunds(bidder, 2 ether, payable(provider));
+        bytes32 bidID = keccak256("1234");
+        bidderRegistry.IdempotentBidFundsMovement(bidID, 2 ether, bidder);
+        bidderRegistry.retrieveFunds(bidID, payable(provider));
         vm.prank(bidderRegistry.owner());
         bidderRegistry.withdrawProtocolFee(payable(address(bidder)));
         uint256 balanceAfter = address(bidder).balance;

--- a/test/BidderRegistryTest.sol
+++ b/test/BidderRegistryTest.sol
@@ -134,7 +134,7 @@ contract BidderRegistryTest is Test {
         vm.prank(bidder);
         bidderRegistry.prepay{value: 2 ether}();
         address provider = vm.addr(4);
-        bidderRegistry.IdempotentBidFundsMovement(bidID, 1 ether, bidder);
+        bidderRegistry.LockBidFunds(bidID, 1 ether, bidder);
         bidderRegistry.retrieveFunds(bidID, payable(provider));
         uint256 providerAmount = bidderRegistry.providerAmount(provider);
         uint256 feeRecipientAmount = bidderRegistry.feeRecipientAmount();
@@ -156,7 +156,7 @@ contract BidderRegistryTest is Test {
         bidderRegistry.prepay{value: 2 ether}();
         address provider = vm.addr(4);
         bytes32 bidID = keccak256("1234");
-        bidderRegistry.IdempotentBidFundsMovement(bidID, 1 ether, bidder);
+        bidderRegistry.LockBidFunds(bidID, 1 ether, bidder);
         bidderRegistry.retrieveFunds(bidID, payable(provider));
 
         uint256 feerecipientValueAfter = bidderRegistry.feeRecipientAmount();
@@ -174,7 +174,7 @@ contract BidderRegistryTest is Test {
         address provider = vm.addr(4);
         vm.expectRevert(bytes(""));
         bytes32 bidID = keccak256("1234");
-        bidderRegistry.IdempotentBidFundsMovement(bidID, 1 ether, bidder);
+        bidderRegistry.LockBidFunds(bidID, 1 ether, bidder);
         bidderRegistry.retrieveFunds(bidID, payable(provider));
     }
 
@@ -189,7 +189,7 @@ contract BidderRegistryTest is Test {
         vm.expectRevert(bytes(""));
         vm.prank(address(this));
         bytes32 bidID = keccak256("1234");
-        bidderRegistry.IdempotentBidFundsMovement(bidID, 3 ether, bidder);
+        bidderRegistry.LockBidFunds(bidID, 3 ether, bidder);
         bidderRegistry.retrieveFunds(bidID, payable(provider));
     }
 
@@ -200,7 +200,7 @@ contract BidderRegistryTest is Test {
         address provider = vm.addr(4);
         uint256 balanceBefore = feeRecipient.balance;
         bytes32 bidID = keccak256("1234");
-        bidderRegistry.IdempotentBidFundsMovement(bidID, 1 ether, bidder);
+        bidderRegistry.LockBidFunds(bidID, 1 ether, bidder);
         bidderRegistry.retrieveFunds(bidID, payable(provider));
         bidderRegistry.withdrawFeeRecipientAmount();
         uint256 balanceAfter = feeRecipient.balance;
@@ -221,7 +221,7 @@ contract BidderRegistryTest is Test {
         address provider = vm.addr(4);
         uint256 balanceBefore = address(provider).balance;
         bytes32 bidID = keccak256("1234");
-        bidderRegistry.IdempotentBidFundsMovement(bidID, 2 ether, bidder);
+        bidderRegistry.LockBidFunds(bidID, 2 ether, bidder);
         bidderRegistry.retrieveFunds(bidID, payable(provider));
         bidderRegistry.withdrawProviderAmount(payable(provider));
         uint256 balanceAfter = address(provider).balance;
@@ -270,7 +270,7 @@ contract BidderRegistryTest is Test {
         bidderRegistry.prepay{value: 5 ether}();
         uint256 balanceBefore = address(bidder).balance;
         bytes32 bidID = keccak256("1234");
-        bidderRegistry.IdempotentBidFundsMovement(bidID, 2 ether, bidder);
+        bidderRegistry.LockBidFunds(bidID, 2 ether, bidder);
         bidderRegistry.retrieveFunds(bidID, payable(provider));
         vm.prank(bidderRegistry.owner());
         bidderRegistry.withdrawProtocolFee(payable(address(bidder)));

--- a/test/OracleTest.sol
+++ b/test/OracleTest.sol
@@ -54,7 +54,7 @@ contract OracleTest is Test {
         vm.startPrank(ownerInstance);
         bidderRegistry.prepay{value: 2 ether}();
         
-        oracle = new Oracle(address(preConfCommitmentStore), 2, ownerInstance);
+        oracle = new Oracle(address(preConfCommitmentStore), address(bidderRegistry), 2, ownerInstance);
         oracle.addBuilderAddress("mev builder", ownerInstance);
         vm.stopPrank();
 

--- a/test/PreConfirmationConfTest.sol
+++ b/test/PreConfirmationConfTest.sol
@@ -42,6 +42,8 @@ contract TestPreConfCommitmentStore is Test {
             feeRecipient, // Oracle
             address(this) // Owner
         );
+
+        bidderRegistry.setPreconfirmationsContract(address(preConfCommitmentStore));
     }
 
     function test_Initialize() public {
@@ -431,9 +433,6 @@ contract TestPreConfCommitmentStore is Test {
                 commitmentSignature
             );
 
-            bidderRegistry.setPreconfirmationsContract(
-                address(preConfCommitmentStore)
-            );
             vm.deal(commiter, 5 ether);
             vm.prank(commiter);
             providerRegistry.registerAndStake{value: 4 ether}();


### PR DESCRIPTION
* This feature ensures no capacity for double spending.
* Introduces bid lifecycle
![Lifecycle of Bid](https://github.com/primevprotocol/contracts/assets/13803371/44780d13-a7fa-444a-be6c-5a5598efec9d)
