### PR TITLE
deploy: whitelist with gateway

### DIFF
--- a/scripts/DeployScripts.s.sol
+++ b/scripts/DeployScripts.s.sol
@@ -77,6 +77,8 @@ contract DeployScript is Script, Create2Deployer {
 contract DeployWhitelist is Script, Create2Deployer {
     function run() external {
 
+        console.log("Warning: DeployWhitelist is deprecated and only for backwards compatibility with hyperlane");
+
         address expectedWhiteListAddr = 0x57508f0B0f3426758F1f3D63ad4935a7c9383620;
         if (isContractDeployed(expectedWhiteListAddr)) {
             console.log("Whitelist already deployed to:", expectedWhiteListAddr);

--- a/scripts/DeployStandardBridge.s.sol
+++ b/scripts/DeployStandardBridge.s.sol
@@ -5,6 +5,7 @@ import {Create2Deployer} from "scripts/DeployScripts.s.sol";
 import {SettlementGateway} from "contracts/standard-bridge/SettlementGateway.sol";
 import {L1Gateway} from "contracts/standard-bridge/L1Gateway.sol";
 import {Whitelist} from "contracts/Whitelist.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 contract DeploySettlementGateway is Script, Create2Deployer {
     function run() external {
@@ -33,7 +34,7 @@ contract DeploySettlementGateway is Script, Create2Deployer {
             address(gateway));
 
         Whitelist whitelist = new Whitelist{salt: salt}(msg.sender);
-        console.log("Whitelist deployed to:", address(whitelist)); 
+        console.log("Whitelist deployed to:", address(whitelist));
 
         if (!isContractDeployed(expectedWhitelistAddr)) {
             console.log("Whitelist not deployed to expected address:", expectedWhitelistAddr);
@@ -42,6 +43,15 @@ contract DeploySettlementGateway is Script, Create2Deployer {
 
         whitelist.addToWhitelist(address(gateway));
         console.log("Settlement gateway has been whitelisted. Gateway contract address:", address(gateway));
+
+        string memory jsonOutput = string.concat(
+            '{"settlement_gateway_addr": "',
+            Strings.toHexString(address(gateway)),
+            '", "whitelist_addr": "',
+            Strings.toHexString(address(whitelist)),
+            '"}'
+        );
+        console.log("JSON_DEPLOY_ARTIFACT:", jsonOutput); 
 
         vm.stopBroadcast();
     }
@@ -66,6 +76,13 @@ contract DeployL1Gateway is Script, Create2Deployer {
             1, 1); // Fees set to 1 wei for now
         console.log("Standard bridge gateway for l1 deployed to:",
             address(gateway));
+        
+        string memory jsonOutput = string.concat(
+            '{"l1_gateway_addr": "',
+            Strings.toHexString(address(gateway)),
+            '"}'
+        );
+        console.log("JSON_DEPLOY_ARTIFACT:", jsonOutput);
 
         vm.stopBroadcast();
     }


### PR DESCRIPTION
Previously with hyperlane, the bridge contract on our settlement layer did not use foundry for deployment. Consequently we had to pass the bridge contract address to the whitelist deployment script as an environment variable. Now that our bridge contracts reside within this repo, we can use a single deploy script that deploys both the `Whitelist` and `SettlementGateway` together. The gateway contract is deployed first, then the whitelist, and finally the address of the gateway contract is whitelisted. This simplifies scripts that use `DeploySettlementGateway` and prevents the need for `grep`ing addresses out of deployment stdout 